### PR TITLE
Removed references to lpo.dt.navy.mil

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Lake Pend Oreille Raw Weather Data from 2012_01_01 00:02:14 to 2015_06_04 01:09:21
 
-This data is used by the Code Clinic series of courses for lynda.com. You can find these courses [here](http://www.lynda.com/SharedPlaylist/3bd14e75f0014f05a34c169289d7a29a). 
+This data is used by the Code Clinic series of courses for lynda.com. You can find these courses [here (at lynda.com)](http://www.lynda.com/SharedPlaylist/3bd14e75f0014f05a34c169289d7a29a) or [here (at LinkedIn Learning)](https://www.linkedin.com/learning/search?entityType=COURSE&keywords=code%20clinic)
 
-This data is posted here for the use of our international friends who cannot access the raw data located [here](http://lpo.dt.navy.mil/data/). The data in this github repository is static - the data on the LPO Navy website is updated every five minutes.
+This data is provided in a static form. The original website, hosted by the US Navy, has gone offline. Please use this data for all experimentation
 
-This data was collected by the [US Navy Acoustic Research Detachment at Lake Pend Oreille](http://lpo.dt.navy.mil/). Their disclaimer and declaration of public domain on this data is located [here](http://lpo.dt.navy.mil/).
+This data was collected by the US Navy Acoustic Research Detachment at Lake Pend Oreille.


### PR DESCRIPTION
lpo.dt.navy.mil has gone offline without warning. This dataset is now used for all code clinics at lynda and linkedin learning.